### PR TITLE
Avoid calling render_sql twice

### DIFF
--- a/tilekiln/config.py
+++ b/tilekiln/config.py
@@ -79,8 +79,7 @@ class Config:
                           sort_keys=True, indent=4)
 
     def layer_queries(self, tile: Tile):
-        return {layer.render_sql(tile) for layer in self.layers
-                if layer.render_sql(tile) is not None}
+        return list(filter(None, (layer.render_sql(tile) for layer in self.layers)))
 
 
 class LayerConfig:


### PR DESCRIPTION
If you have a generator of the form

```
[f(x) for x in foo if f(x)]
```

then Python has to call function `f()` twice for every element because it cannot know if `f()` has side-effects. What you want to do here instead apply a filter to the results.

NB: do you really want to eliminate duplicates here? If not, then it would be faster to return a list instead of a set.