### PR TITLE
Increase chunk-size for sending data to generator workers

### DIFF
--- a/tilekiln/generator.py
+++ b/tilekiln/generator.py
@@ -48,6 +48,6 @@ def generate(config: Config, source_kwargs, storage_kwargs,  # type: ignore[no-u
         return
 
     with mp.Pool(num_processes, setup, (config, source_kwargs, storage_kwargs)) as pool:
-        pool.imap_unordered(worker, tiles)
+        pool.imap_unordered(worker, tiles, 100)
         pool.close()
         pool.join()


### PR DESCRIPTION
To quote the [Python documentation](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap), _"... For very long iterables using a large value for chunksize can make the job complete **much** faster than using the default value of 1"_.

A chunk size of 100 gives a nice speed-up. I haven't done any systematic testing of the optimal value.