### PR TITLE
Switch to layered storage

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,323 @@
+import json
+import queue
 from unittest import TestCase
+
+from tilekiln.storage import Storage
+from tilekiln.tile import Tile
+from tilekiln.metric import Metric
+import tilekiln.errors
+
+
+class FakeCursor:
+    def __init__(self, calls, rets):
+        self.calls = calls
+        self.rets = rets
+
+    def execute(self, query, vars=None, binary=None):
+        try:
+            self.calls.append(query.as_string())
+        except AttributeError:
+            self.calls.append(query)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return self.rets.get_nowait()
+        except queue.Empty:
+            raise StopIteration
+
+    def fetchone(self):
+        return next(self)
+
+
+class FakeCursCM:
+    def __init__(self, calls, rets):
+        self.curs = FakeCursor(calls, rets)
+
+    def __enter__(self):
+        return self.curs
+
+    def __exit__(*args):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, calls, rets):
+        self.curs = FakeCursCM(calls, rets)
+
+    def cursor(self, row_factory=None):
+        return self.curs
+
+    def commit(self):
+        pass
+
+
+class FakeConnCM:
+    def __init__(self, calls, rets):
+        self.conn = FakeConnection(calls, rets)
+
+    def __enter__(self):
+        return self.conn
+
+    def __exit__(*args):
+        pass
+
+
+class FakePool:
+    def __init__(self, calls: list[str], rets: queue.Queue[dict[str, str]]):
+        self.cm = FakeConnCM(calls, rets)
+
+    def connection(self):
+        return self.cm
 
 
 class TestStorage(TestCase):
-    maxDiff = None
+    def test_schema(self):
+        calls = []
+        rets = queue.SimpleQueue()
+        pool = FakePool(calls, rets)
+
+        storage = Storage(pool)
+
+        storage.create_schema()
+
+        self.assertRegex(calls[0], r"(?ims)CREATE SCHEMA.*tilekiln")
+        self.assertRegex(calls[1], r"(?ims)CREATE.*TABLE.*generate_stats.*id.*zoom.*")
+        self.assertRegex(calls[2], r"(?ims)CREATE.*TABLE.*tile_stats.*id.*zoom.*")
+        self.assertRegex(calls[3], r"(?ims)CREATE.*TABLE.*metadata.*")
+        self.assertRegex(calls[3], r"id text")
+        self.assertRegex(calls[3], r"active boolean")
+        self.assertRegex(calls[3], r"layers text\[\]")
+        self.assertRegex(calls[3], r"minzoom smallint")
+        self.assertRegex(calls[3], r"maxzoom smallint")
+        calls.clear()
+
+    def test_tileset(self):
+        calls = []
+        rets = queue.SimpleQueue()
+        pool = FakePool(calls, rets)
+
+        storage = Storage(pool)
+
+        storage.create_tileset("foo", ["lyr1", "lyr2"], 0, 2, "{}")
+
+        self.assertRegex(calls[0], r"(?ims)INSERT INTO.*metadata.*VALUES.*ON CONFLICT")
+        self.assertRegex(calls[1], r"(?ims)CREATE TABLE.*foo.*")
+        self.assertRegex(calls[1], r'''(?ims)"lyr1_generated" timestamptz''')
+        self.assertRegex(calls[1], r'''(?ims)"lyr1_data" bytea''')
+        # Check timestamps are before tile data for storage reasons
+        self.assertRegex(calls[1], r'''(?ims)timestamptz.*bytea''')
+        self.assertNotRegex(calls[1], r'''(?ims)bytea.*timestamptz''')
+
+        self.assertRegex(calls[2], r"(?ims)CREATE TABLE.*foo_z0")
+        self.assertRegex(calls[2], r"(?ims)PARTITION OF.*foo")
+        self.assertRegex(calls[2], r"(?ims)FOR VALUES IN \(0\)")
+        self.assertRegex(calls[3], r"(?ims)CREATE TABLE.*foo_z1")
+        self.assertRegex(calls[3], r"(?ims)PARTITION OF.*foo")
+        self.assertRegex(calls[3], r"(?ims)FOR VALUES IN \(1\)")
+        self.assertRegex(calls[4], r"(?ims)CREATE TABLE.*foo_z2")
+        self.assertRegex(calls[4], r"(?ims)PARTITION OF.*foo")
+        self.assertRegex(calls[4], r"(?ims)FOR VALUES IN \(2\)")
+        calls.clear()
+
+        storage.remove_tileset("foo")
+
+        self.assertRegex(calls[0], r"(?ims)DELETE FROM.*metadata.*id")
+        self.assertRegex(calls[1], r"(?ims)DROP TABLE.*foo")
+        self.assertRegex(calls[2], r"(?ims)DELETE FROM.*tile_stats.*id")
+        calls.clear()
+
+        rets.put({"id": "foo"})
+        rets.put({"id": "bar"})
+
+        ids = storage.get_tileset_ids()
+
+        self.assertEqual(next(ids), "foo")
+        self.assertEqual(next(ids), "bar")
+        self.assertRegex(calls[0], r"(?ims)SELECT id.*metadata")
+
+        calls.clear()
+        while not rets.empty():
+            queue.get()
+
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 2,
+                  "tilejson": json.loads("{}")
+                  })
+
+        tilesets = storage.get_tilesets()
+        tileset = next(tilesets)
+        self.assertRegex(calls[0], r"(?ims)SELECT id.*metadata")
+        self.assertEqual(tileset.id, "foo")
+        self.assertEqual(tileset.layers, ["lyr1", "lyr2"])
+        self.assertEqual(tileset.minzoom, 0)
+        self.assertEqual(tileset.maxzoom, 2)
+        self.assertEqual(tileset.tilejson, '{}')
+
+    def test_metadata(self):
+        calls = []
+        rets = queue.SimpleQueue()
+        pool = FakePool(calls, rets)
+
+        storage = Storage(pool)
+        storage.set_metadata("foo", ["lyr1", "lyr2"], 0, 3, "{}")
+
+        self.assertRegex(calls[0], r"(?ims)INSERT INTO.*metadata.*VALUES.*ON CONFLICT")
+        calls.clear()
+
+    def test_tiles(self):
+        calls = []
+        rets = queue.SimpleQueue()
+        pool = FakePool(calls, rets)
+
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 2,
+                  "tilejson": json.loads("{}")
+                  })
+        rets.put({"lyr1_data": b"bar", "lyr2_data": b"baz", "generated": "datetime"})
+        storage = Storage(pool)
+        result, generated = storage.get_tile("foo", Tile(0, 0, 0))
+        self.assertEqual(result["lyr1"], b"bar")
+        self.assertEqual(result["lyr2"], b"baz")
+        self.assertEqual(generated, "datetime")
+
+        # calls[0] is get_tileset call tested above. TODO: test it above
+        self.assertRegex(calls[1],
+                         r"(?ims)SELECT.*lyr1_generated.*.*lyr1_data.*FROM.*foo.*WHERE.*zoom")
+
+        calls.clear()
+        while not rets.empty():
+            queue.get()
+
+        # Test no tile found
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 2,
+                  "tilejson": json.loads("{}")
+                  })
+        rets.put(None)
+        self.assertEqual(storage.get_tile("foo", Tile(0, 0, 0)), (None, None))
+
+        calls.clear()
+        while not rets.empty():
+            queue.get()
+
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 2,
+                  "tilejson": json.loads("{}")
+                  })
+        rets.put({"generated": "datetime"})
+
+        self.assertEqual(storage.save_tile("foo", Tile(2, 1, 0),
+                                           {"lyr1": b"bar", "lyr2": b"baz"}), "datetime")
+        self.assertRegex(calls[0], r"(?ims)minzoom.*maxzoom")
+        self.assertRegex(calls[1], r"(?ims)INSERT INTO.*foo_z2")
+        # Test colums are right
+        self.assertRegex(calls[1],
+                         r"(?ms)\(zoom[^\)]+x[^\)]+y[^\)]+lyr1_data[^\)]+lyr2_data[^\)]*\)")
+        self.assertRegex(calls[1],
+                         r'''(?ims)VALUES\s+\(\s*2,\s+1,\s+0,\s+'''
+                         r'''\%\([^\)]*\)s,\s+\%\([^\)]*\)s\s*\)''')
+        self.assertRegex(calls[1],
+                         r"(?ims)ON CONFLICT\s+\(zoom,\s+x,\s+y\s*\)")
+        # Test that the upsert sets data to something based on excluded
+        self.assertRegex(calls[1], r"(?ims)DO UPDATE.*lyr1_data[^,]+=[^,]*EXCLUDED[^,]+lyr1_data")
+        self.assertRegex(calls[1], r"(?ims)DO UPDATE.*lyr2_data[^,]+=[^,]*EXCLUDED[^,]+lyr2_data")
+
+        # test that upserts sets generated to something based on stored and new lyr1_generated,
+        # statement_timestamp, and that old generated is referenced
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr1_generated[^,]*=[^,]*STORE\.[^,]*lyr1_data")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr1_generated[^,]*=[^,]*EXCLUDED\.[^,]*lyr1_data")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr1_generated[^,]+=[^,]*statement_timestamp")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr1_generated[^,]+=[^,]*STORE\.[^,]*lyr1_generated")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr2_generated[^,]*=[^,]*STORE\.[^,]*lyr2_data")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr2_generated[^,]*=[^,]*EXCLUDED\.[^,]*lyr2_data")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr2_generated[^,]+=[^,]*statement_timestamp")
+        self.assertRegex(calls[1],
+                         r"(?ims)DO UPDATE.*lyr2_generated[^,]+=[^,]*STORE\.[^,]*lyr2_generated")
+
+        self.assertRegex(calls[1],
+                         r"(?ims)RETURNING.*lyr1_generated")
+        self.assertRegex(calls[1],
+                         r"(?ims)RETURNING.*lyr2_generated")
+
+        calls.clear()
+        while not rets.empty():
+            queue.get()
+
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 2,
+                  "tilejson": json.loads("{}")
+                  })
+        rets.put({"generated": "datetime"})
+
+        # Check that an exception is raised if trying to save a tile with missing layers
+        self.assertRaises(tilekiln.errors.Error, storage.save_tile, "foo", Tile(2, 1, 0),
+                          {"lyr1": b"bar"}, "datetime")
+
+    def test_metrics(self):
+        calls = []
+        rets = queue.SimpleQueue()
+        pool = FakePool(calls, rets)
+
+        storage = Storage(pool)
+
+        rets.put({"id": "foo",
+                  "zoom": 0,
+                  "num_tiles": 1,
+                  "size": 1024,
+                  "percentiles": [0, 1, 2]})
+        rets.put({"id": "foo",
+                  "zoom": 1,
+                  "num_tiles": 4,
+                  "size": 4096,
+                  "percentiles": [0, 1, 2]})
+        metrics = storage.metrics()
+        self.assertEqual(metrics[0], Metric(id="foo", zoom=0, num_tiles=1,
+                         size=1024, percentiles=[0, 1, 2]))
+        self.assertEqual(metrics[1], Metric(id="foo", zoom=1, num_tiles=4,
+                         size=4096, percentiles=[0, 1, 2]))
+
+        self.assertRegex(calls[0], r"(?ims)SELECT.*id.*zoom.*num_tiles.*size.*percentiles")
+        self.assertRegex(calls[0], r"(?ims)FROM.*tile_stats")
+        # update_metrics
+
+        calls.clear()
+        while not rets.empty():
+            queue.get()
+
+        rets.put({"id": "foo",
+                  "layers": ["lyr1", "lyr2"],
+                  "minzoom": 0,
+                  "maxzoom": 1,
+                  "tilejson": json.loads("{}")
+                  })
+
+        storage.update_metrics()
+
+        # calls 0 and 1 are get_tileset and JIT statements
+        self.assertRegex(calls[2], r"(?i)INSERT INTO.*tile_stats")
+        self.assertRegex(calls[2], r'''(?ims)SUM\(length\("?lyr1_data"?\)'''
+                                   r'''\+length\("?lyr2_data"?\)\)''')
+        self.assertRegex(calls[2], r'''(?ims)ARRAY\[.*COALESCE\(PERCENTILE_CONT\(.*\).*\).*\]''')
+        self.assertRegex(calls[2], r"(?i)FROM.*foo_z0")
+        # call 3 is JIT
+        self.assertRegex(calls[4], r"(?i)FROM.*foo_z1")

--- a/tilekiln/dev/__init__.py
+++ b/tilekiln/dev/__init__.py
@@ -80,6 +80,6 @@ def serve_tile(prefix: str, zoom: int, x: int, y:  int):
     if prefix != config.id:
         raise HTTPException(status_code=404, detail=f"Tileset {prefix} not found on server.")
     global kiln
-    return Response(kiln.render(Tile(zoom, x, y)),
-                    media_type="application/vnd.mapbox-vector-tile",
+    tile = b''.join(kiln.render_all(Tile(zoom, x, y)).values())
+    return Response(tile, media_type="application/vnd.mapbox-vector-tile",
                     headers=STANDARD_HEADERS)

--- a/tilekiln/errors.py
+++ b/tilekiln/errors.py
@@ -3,8 +3,8 @@ Custom exceptions used by tilekiln
 
 Exception (base)
 |_ Error
-   |_ConfigError
-   |_RuntimeError
+   |_ ConfigError
+   |_ RuntimeError
 '''
 
 
@@ -34,4 +34,8 @@ class RuntimeError(Error):
 
 
 class ZoomNotDefined(RuntimeError):
+    pass
+
+
+class TilesetMissing(RuntimeError):
     pass

--- a/tilekiln/scripts/config.py
+++ b/tilekiln/scripts/config.py
@@ -40,21 +40,19 @@ def sql(config: str, layer: str, zoom: int, x: int, y: int):
     c = tilekiln.load_config(config)
 
     if layer is None:
-        for sql in c.layer_queries(Tile(zoom, x, y)):
-            click.echo(sql)
+        for sql in c.layer_queries(Tile(zoom, x, y)).values():
+            if sql is not None:
+                click.echo(sql)
         return 0
     else:
-        # Iterate through the layers to find the right one
         try:
-            lc = c.__layers[layer]
+            sql = c.layer_query(layer, Tile(zoom, x, y))
         except KeyError:
             click.echo(f"Layer '{layer}' not found in configuration", err=True)
             return 1
-
-        sql = lc.render_sql(Tile(zoom, x, y))
         if sql is None:
-            click.echo((f"Zoom {zoom} not between min zoom {lc.minzoom} "
-                        f"and max zoom {lc.maxzoom} for layer {layer}."), err=True)
+            click.echo((f"Zoom {zoom} not between min zoom and max zoom for layer {layer}."),
+                       err=True)
             return 1
         click.echo(sql)
         return 0

--- a/tilekiln/server/__init__.py
+++ b/tilekiln/server/__init__.py
@@ -155,7 +155,7 @@ def serve_tile(prefix: str, zoom: int, x: int, y: int):
     if generated is not None:
         headers = {"Last-Modified": generated.strftime(HTTP_TIME),
                    "E-tag": generated.strftime("%s.%f")}
-    return Response(tile, media_type=MVT_MIME_TYPE,
+    return Response(b''.join(tile.values()), media_type=MVT_MIME_TYPE,
                     headers=STANDARD_HEADERS | headers)
 
 
@@ -179,18 +179,18 @@ def live_serve_tile(prefix: str, zoom: int, x: int, y:  int):
         if generated is not None:
             headers = {"Last-Modified": generated.strftime(HTTP_TIME),
                        "E-tag": generated.strftime("%s.%f")}
-        return Response(existing, media_type=MVT_MIME_TYPE,
+        return Response(b''.join(existing.values()), media_type=MVT_MIME_TYPE,
                         headers=STANDARD_HEADERS | headers)
 
     # Storage miss, so generate a new tile
     global kiln
     tile = Tile(zoom, x, y)
-    response = kiln.render(tile)
+    layers = kiln.render_all(tile)
     # TODO: Make async so tile is saved and response returned in parallel
-    generated = tilesets[prefix].save_tile(tile, response)
+    generated = tilesets[prefix].save_tile(tile, layers)
     if generated is not None:
         headers = {"Last-Modified": generated.strftime(HTTP_TIME),
                    "E-tag": generated.strftime("%s.%f")}
-    return Response(response,
+    return Response(b''.join(layers.values()),
                     media_type=MVT_MIME_TYPE,
                     headers=STANDARD_HEADERS | headers)

--- a/tilekiln/storage.py
+++ b/tilekiln/storage.py
@@ -1,11 +1,13 @@
 import datetime
 import json
 import sys
-from collections.abc import Iterator
+from collections.abc import Collection, Iterator, Sequence
+from typing import Optional
 
 import click
 import psycopg.rows
 import psycopg_pool
+from psycopg import sql
 
 import tilekiln.errors
 
@@ -30,7 +32,7 @@ class Storage:
     A Storage contains tiles and metadata about tilesets, and has functions to update
     tiles and metadata based on the ID
     '''
-    def __init__(self, pool: psycopg_pool.ConnectionPool, schema="tilekiln"):
+    def __init__(self, pool: psycopg_pool.ConnectionPool, schema: str = "tilekiln"):
         self.__pool = pool
         self.__schema = schema
 
@@ -50,12 +52,13 @@ class Storage:
     '''
     Methods for tilesets
     '''
-    def create_tileset(self, id: str, minzoom: int, maxzoom: int, tilejson: str) -> None:
+    def create_tileset(self, id: str, layers: list[str],
+                       minzoom: int, maxzoom: int, tilejson: str) -> None:
         with self.__pool.connection() as conn:
             with conn.cursor() as cur:
-                self.__set_metadata(cur, id, minzoom, maxzoom, tilejson)
+                self.__set_metadata(cur, id, layers, minzoom, maxzoom, tilejson)
 
-                self.__setup_tables(cur, id, minzoom, maxzoom)
+                self.__setup_tables(cur, id, layers, minzoom, maxzoom)
             conn.commit()
 
     def remove_tileset(self, id: str) -> None:
@@ -75,11 +78,30 @@ class Storage:
 
         with self.__pool.connection() as conn:
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-                cur.execute(f'''SELECT id, minzoom, maxzoom, tilejson
+                cur.execute(f'''SELECT id, layers, minzoom, maxzoom, tilejson
                                 FROM "{self.__schema}"."{METADATA_TABLE}"''')
                 for record in cur:
-                    yield Tileset(self, record["id"], record["minzoom"], record["maxzoom"],
+                    yield Tileset(self, record["id"], record["layers"],
+                                  record["minzoom"], record["maxzoom"],
                                   json.dumps(record["tilejson"]))
+
+    def get_tileset(self, id: str) -> Tileset:
+        '''
+        Gets all tilesets in the storage
+        '''
+
+        with self.__pool.connection() as conn:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                cur.execute(sql.SQL('''SELECT id, layers, minzoom, maxzoom, tilejson FROM {}.{}''')
+                            .format(sql.Identifier(self.__schema), sql.Identifier(METADATA_TABLE)) +
+                            sql.SQL('''WHERE id = %s'''), (id, ))
+                result = cur.fetchone()
+                if result is None:
+                    raise tilekiln.errors.TilesetMissing
+
+                return Tileset(self, result["id"], result["layers"],
+                               result["minzoom"], result["maxzoom"],
+                               json.dumps(result["tilejson"]))
 
     def get_tileset_ids(self) -> Iterator[str]:
         '''
@@ -94,25 +116,24 @@ class Storage:
                     yield record["id"]
 
     ''' Methods for metrics'''
-    def metrics(self) -> Iterator[Metric]:
+    def metrics(self) -> Collection[Metric]:
         with self.__pool.connection() as conn:
-            with conn.cursor(row_factory=psycopg.rows.class_row(Metric)) as cur:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 cur.execute(f'''SELECT id, zoom, num_tiles, size, percentiles
                                 FROM "{self.__schema}"."{TILE_STATS_TABLE}"''')
-                for record in cur:
-                    yield record
+                return [Metric(**record) for record in cur]
 
     def update_metrics(self) -> None:
+        tilesets = self.get_tilesets()
         with self.__pool.connection() as conn:
             with conn.cursor() as cur:
-                for id in self.get_tileset_ids():
-                    minzoom = self.get_minzoom(id)
-                    maxzoom = self.get_maxzoom(id)
-                    self.__update_tileset_metrics(cur, id, minzoom, maxzoom)
+                for tileset in tilesets:
+                    self.__update_tileset_metrics(cur, tileset)
                 conn.commit()
 
     '''Methods that set/get metadata'''
-    def set_metadata(self, id, minzoom, maxzoom, tilejson):
+    def set_metadata(self, id: str, layers: list[str],
+                     minzoom: int, maxzoom: int, tilejson: str) -> None:
         '''
         Saves metadata into storage
 
@@ -120,12 +141,16 @@ class Storage:
         '''
         with self.__pool.connection() as conn:
             with conn.cursor() as cur:
-                self.__set_metadata(cur, id, minzoom, maxzoom, tilejson)
-                self.__conn.commit()
+                self.__set_metadata(cur, id, layers, minzoom, maxzoom, tilejson)
+            conn.commit()
+
+    def get_layer_ids(self, id: str) -> list[str]:
+        ''''''
+        raise NotImplementedError()
 
     # TODO: Should the various get_* functions be separate? The query has to fetch from the
     # DB each time, but only tilejson needs URL. Not an urgent issue.
-    def get_tilejson(self, id, url) -> str:
+    def get_tilejson(self, id: str, url: str) -> str:
         '''Gets the tilejson for a layer from storage.'''
         with self.__pool.connection() as conn:
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -143,7 +168,8 @@ class Storage:
                 tilejson["tiles"] = [f"{url}" + "/{z}/{x}/{y}.mvt"]
                 return json.dumps(tilejson)
 
-    def get_minzoom(self, id):
+    # TODO: Get rid of get_minzoom/maxzoom functions and use get_tileset
+    def get_minzoom(self, id: str):
         '''Gets the minzoom for a layer from storage.'''
         with self.__pool.connection() as conn:
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -184,59 +210,87 @@ class Storage:
                     self.__delete_tile(cur, id, tile)
             conn.commit()
 
-    def truncate_tables(self, id: str, zooms=None):
+    def truncate_tables(self, id: str, zooms: Optional[Sequence[int]] = None):
+        if zooms is None:
+            zooms = range(self.get_minzoom(id), self.get_maxzoom(id)+1)
         with self.__pool.connection() as conn:
             with conn.cursor() as cur:
-                if zooms is None:
-                    zooms = range(self.get_minzoom(id), self.get_maxzoom(id)+1)
                 for zoom in zooms:
                     self.__truncate_table(cur, id, zoom)
             conn.commit()
 
-    def get_tile(self, id: str, tile: Tile) -> tuple[bytes | None, datetime.datetime | None]:
+    def get_tile(self, id: str, tile: Tile) -> tuple[dict[str, bytes] | None,
+                                                     datetime.datetime | None]:
+        tileset = self.get_tileset(id)
+        if tile.zoom > tileset.maxzoom or tile.zoom < tileset.minzoom:
+            raise tilekiln.errors.ZoomNotDefined
         with self.__pool.connection() as conn:
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-                try:
-                    cur.execute(f'''SELECT generated, tile FROM "{self.__schema}"."{id}"
-                                    WHERE zoom = %s AND x = %s AND y = %s''',
-                                (tile.zoom, tile.x, tile.y), binary=True)
-                except psycopg.errors.UndefinedTable:
-                    raise tilekiln.errors.ZoomNotDefined
-
+                query = (sql.SQL('SELECT GREATEST(')
+                         + generated_columns(tileset.layers)
+                         + sql.SQL(') AS generated,')
+                         + data_columns(tileset.layers)
+                         + sql.SQL('FROM {}.{}').format(sql.Identifier(self.__schema),
+                                                        sql.Identifier(id))
+                         + sql.SQL('WHERE zoom = %s AND x = %s AND y = %s'))
+                cur.execute(query, (tile.zoom, tile.x, tile.y), binary=True)
                 result = cur.fetchone()
                 if result is None:
                     return None, None
-                return result["tile"], result["generated"]
+                return {layer: result[f"{layer}_data"]
+                        for layer in tileset.layers}, result["generated"]
 
-    # TODO: Needs to return timestamp written to the DB
     def save_tile(self, id: str, tile: Tile,
-                  tiledata: bytes, render_time=0) -> datetime.datetime | None:
+                  layers: dict[str, bytes], render_time=0) -> datetime.datetime | None:
+        tileset = self.get_tileset(id)
+        if tile.zoom > tileset.maxzoom or tile.zoom < tileset.minzoom:
+            raise tilekiln.errors.ZoomNotDefined
+        if tileset.layers != list(layers.keys()):
+            raise tilekiln.errors.Error("Layers rendered do not match layers specified")
+        tablename = f"{id}_z{tile.zoom}"
+
         with self.__pool.connection() as conn:
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 # TODO: This statement unconditionally writes the row even if it's unchanged. It
                 # shouldn't. Adding WHERE tile != EXCLUDED.tile would help, but then it would
                 # return zero rows if the contents are the same. The method here instead results
                 # in extra writes but does preserve the datetime.
-                tablename = f"{id}_z{tile.zoom}"
-                try:
-                    cur.execute(f'''INSERT INTO "{self.__schema}"."{tablename}" AS store\n'''
-                                '''(zoom, x, y, tile)\n'''
-                                '''VALUES (%s, %s, %s, %s)\n'''
-                                '''ON CONFLICT (zoom, x, y)\n'''
-                                '''DO UPDATE SET tile = EXCLUDED.tile,\n'''
-                                '''generated = CASE WHEN store.tile != EXCLUDED.tile\n'''
-                                '''    THEN statement_timestamp()\n'''
-                                '''    ELSE store.generated END\n'''
-                                '''RETURNING generated''',
-                                (tile.zoom, tile.x, tile.y, tiledata))
-                except psycopg.errors.UndefinedTable:
-                    raise tilekiln.errors.ZoomNotDefined
+
+                # These statements operate on the
+
+                data_upsert = [sql.SQL("{} = EXCLUDED.{}").format(sql.Identifier(f"{layer}_data"),
+                                                                  sql.Identifier(f"{layer}_data"))
+                               for layer in tileset.layers]
+                time_upsert = [sql.SQL("{generated} = CASE WHEN store.{data} != EXCLUDED.{data} "
+                                       "THEN statement_timestamp() ELSE store.{generated} END")
+                               .format(generated=sql.Identifier(f"{layer}_generated"),
+                                       data=sql.Identifier(f"{layer}_data"))
+                               for layer in layers]
+
+                # arguments to the query
+                data_idents = [sql.Placeholder(layer) for layer in layers]
+
+                q = (sql.SQL("INSERT INTO {}.{} AS store\n").format(sql.Identifier(self.__schema),
+                                                                    sql.Identifier(tablename))
+                     + sql.SQL("(zoom, x, y, ") + data_columns(layers) + sql.SQL(")\n")
+                     + sql.SQL("VALUES ({}, {}, {}, ").format(sql.Literal(tile.zoom),
+                                                              sql.Literal(tile.x),
+                                                              sql.Literal(tile.y))
+                     + sql.SQL(", ").join(data_idents) + sql.SQL(")\n")
+                     + sql.SQL("ON CONFLICT (zoom, x, y)\n")
+                     + sql.SQL("DO UPDATE SET ")
+                     + sql.SQL(", ").join([*data_upsert, *time_upsert])
+                     + sql.SQL("\nRETURNING GREATEST(") + generated_columns(layers)
+                     + sql.SQL(") AS generated"))
+
+                cur.execute(q, layers)
+
                 result = cur.fetchone()
                 if result is None:
                     return None
                 return result["generated"]
 
-    def __setup_metadata(self, cur):
+    def __setup_metadata(self, cur) -> None:
         ''' Create the metadata table in storage. This is safe to rerun
         '''
         # TODO: Updating metadata table schema??
@@ -245,27 +299,30 @@ class Storage:
         cur.execute(f'''CREATE TABLE IF NOT EXISTS "{self.__schema}"."{METADATA_TABLE}" (\n'''
                     '''id text PRIMARY KEY,\n'''
                     '''active boolean NOT NULL DEFAULT TRUE,\n'''
+                    '''layers text[],\n'''
                     '''minzoom smallint NOT NULL,\n'''
                     '''maxzoom smallint NOT NULL,\n'''
                     '''tilejson jsonb NOT NULL)''')
 
-    def __set_metadata(self, cur, id, minzoom, maxzoom, tilejson):
+    def __set_metadata(self, cur, id: str, layers: list[str], minzoom, maxzoom, tilejson):
         '''
         Sets metadata using a cursor
 
         This is separate from set_metadata because sometimes it needs
         calling within a transaction
         '''
-        cur.execute(f'''INSERT INTO "{self.__schema}"."{METADATA_TABLE}"
-        (id, minzoom, maxzoom, tilejson)
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT (id)
-        DO UPDATE SET minzoom = EXCLUDED.minzoom,
-        maxzoom = EXCLUDED.maxzoom,
-        tilejson = EXCLUDED.tilejson
-        ''', (id, minzoom, maxzoom, tilejson))
 
-    def __setup_stats(self, cur):
+        query = (sql.SQL("INSERT INTO {}.{}\n").format(sql.Identifier(self.__schema),
+                                                       sql.Identifier(METADATA_TABLE))
+                 + sql.SQL("(id, minzoom, maxzoom, layers, tilejson)\n")
+                 + sql.SQL("VALUES (%s, %s, %s, %s, %s)\n")
+                 + sql.SQL("ON CONFLICT (id)\n")
+                 + sql.SQL("DO UPDATE SET minzoom = EXCLUDED.minzoom,\n")
+                 + sql.SQL("maxzoom = EXCLUDED.maxzoom,\n")
+                 + sql.SQL("tilejson = EXCLUDED.tilejson"))
+        cur.execute(query, (id, minzoom, maxzoom, layers, tilejson))
+
+    def __setup_stats(self, cur) -> None:
         '''Create the stats tables.
 
         One table has tile generation stats, the other has tile storage stats.
@@ -298,9 +355,11 @@ class Storage:
         )
         ''')
 
-    def __update_tileset_metrics(self, cur, id, minzoom, maxzoom) -> None:
+    def __update_tileset_metrics(self, cur, tileset: Tileset) -> None:
+        id = tileset.id
+        minzoom = tileset.minzoom
+        maxzoom = tileset.maxzoom
         for zoom in range(minzoom, maxzoom+1):
-            tablename = f"{id}_z{zoom}"
             # This SQL statement needs to handle the case of an empty table.
             # Except for COUNT(*) the aggregate functions return NULL for
             # no rows, which is a problem. One option would be to save
@@ -312,65 +371,67 @@ class Storage:
             # slows down rendering queries.
             # TODO: Consider if it would be better to completely skip the row
             #       and emit no metric.
-            # TODO: Reformat this statement to be better with line breaks
             cur.execute('SET LOCAL jit TO ON;')
-            cur.execute(f'''INSERT INTO "{self.__schema}"."{TILE_STATS_TABLE}"
-                        SELECT
-                            %(id)s AS id,
-                            %(zoom)s AS zoom,
-                            COUNT(*) AS num_tiles,
-                            COALESCE(SUM(length(tile)),0) AS size,
-                            ARRAY[%(percentile)s,
-                                COALESCE(PERCENTILE_CONT(%(percentile)s::double precision[])
-                                    WITHIN GROUP (ORDER BY length(tile)),
-                                    array_fill(0,
-                                    ARRAY[array_length(%(percentile)s, 1)]))] AS percentiles
-                            FROM "{self.__schema}"."{tablename}"
-                            ON CONFLICT (id, zoom)
-                        DO UPDATE SET num_tiles = EXCLUDED.num_tiles,
-                            size = EXCLUDED.size,
-                            percentiles = EXCLUDED.percentiles;
-                        ''', {'id': id, 'zoom': zoom, 'percentile': PERCENTILES})
 
-    def __setup_tables(self, cur, id, minzoom, maxzoom):
+            length = sql.SQL("+").join([sql.SQL("length({})")
+                                        .format(sql.Identifier(f"{layer}_data"))
+                                        for layer in tileset.layers])
+
+            query = (sql.SQL("INSERT INTO {}.{}\n").format(sql.Identifier(self.__schema),
+                                                           sql.Identifier(TILE_STATS_TABLE))
+                     + sql.SQL("SELECT %(id)s AS id, %(zoom)s AS zoom,")
+                     + sql.SQL("COUNT(*) AS num_tiles,\n"
+                               + "COALESCE (SUM({}), 0) AS size,\n").format(length)
+
+                     + sql.SQL("ARRAY[%(percentile)s, "
+                               + "COALESCE(PERCENTILE_CONT(%(percentile)s::double precision[])")
+                     + sql.SQL("WITHIN GROUP (ORDER BY {}),\n").format(length)
+                     + sql.SQL("array_fill(0, ARRAY[array_length(%(percentile)s, 1)]))] "
+                               + "AS percentiles\n").format(length, length)
+                     + sql.SQL("FROM {}.{}").format(sql.Identifier(self.__schema),
+                                                    sql.Identifier(f"{id}_z{zoom}"))
+                     + sql.SQL("ON CONFLICT (id, zoom)\n"
+                               + "DO UPDATE SET num_tiles = EXCLUDED.num_tiles,\n"
+                               + "size = EXCLUDED.size,\n"
+                               + "percentiles = EXCLUDED.percentiles;"))
+
+            cur.execute(query, {'id': id, 'zoom': zoom, 'percentile': PERCENTILES})
+
+    def __setup_tables(self, cur, id: str, layers: list[str],
+                       minzoom: int, maxzoom: int) -> None:
         '''Create the tile storage tables
 
         This creates the tile storage tables. It intentionally
         does not try to overwrite existing tables.
         '''
-        # These columns are ordered to minimize wasted space between columns
-        cur.execute(f'''CREATE TABLE "{self.__schema}"."{id}" (
-                    zoom smallint CHECK (zoom >= {minzoom} AND zoom <= {maxzoom}),
-                    x int CHECK (x >= 0 AND x < 1 << zoom),
-                    y int CHECK (y >= 0 AND y < 1 << zoom),
-                    generated timestamptz DEFAULT statement_timestamp(),
-                    tile bytea NOT NULL,
-                    primary key (zoom, x, y)
-                    ) PARTITION BY LIST (zoom)''')
+
+        columns = [sql.SQL('zoom smallint CHECK (zoom >= {} AND zoom <= {})')
+                   .format(sql.Literal(minzoom), sql.Literal(maxzoom)),
+                   sql.SQL('x int CHECK (x >= 0 AND x < 1 << zoom)'),
+                   sql.SQL('y int CHECK (y >= 0 AND y < 1 << zoom)')]
+
+        columns += [sql.SQL("{} timestamptz DEFAULT statement_timestamp()")
+                    .format(sql.Identifier(f'{layer}_generated'))
+                    for layer in layers]
+        columns += [sql.SQL("{} bytea").format(sql.Identifier(f'{layer}_data'))
+                    for layer in layers]
+        columns += [sql.SQL("PRIMARY KEY (zoom, x, y)")]
+
+        query = (sql.SQL('''CREATE TABLE {}.{} (\n''').format(sql.Identifier(self.__schema),
+                                                              sql.Identifier(id))
+                 + sql.SQL(',\n').join(columns)
+                 + sql.SQL(''') PARTITION BY LIST (zoom)'''))
+
+        cur.execute(query)
         for zoom in range(minzoom, maxzoom+1):
             tablename = f"{id}_z{zoom}"
-            cur.execute(f'''CREATE TABLE "{self.__schema}"."{tablename}"
-                            PARTITION OF "{self.__schema}"."{id}"
-                            FOR VALUES IN ({zoom})''')
+            query = (sql.SQL('''CREATE TABLE {}.{}\n''').format(sql.Identifier(self.__schema),
+                                                                sql.Identifier(tablename))
+                     + sql.SQL('''PARTITION OF {}.{}\n''').format(sql.Identifier(self.__schema),
+                                                                  sql.Identifier(id))
+                     + sql.SQL('''FOR VALUES IN ({})''').format(sql.Literal(zoom)))
 
-    def __load_metadata(self):
-        '''Load the stored metadata.
-
-        This allows serving a TileJSON without having access to the config
-        '''
-        with self.__conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(f'''SELECT minzoom, maxzoom, tilejson
-                            FROM "{self.__schema}"."{METADATA_TABLE}"
-                            WHERE id = %s''', (self.id,))
-            result = cur.fetchone()
-            if result is None:
-                # TODO: raise exception and handle it at the calling level
-                click.echo(f"Failed to retrieve metadata for id {self.id}, "
-                           "does it exist in storage DB?", err=True)
-                sys.exit(1)
-            self.minzoom = result["minzoom"]
-            self.maxzoom = result["maxzoom"]
-            self.__rawtilejson = result["tilejson"]
+            cur.execute(query)
 
     def __truncate_table(self, cur, id: str, zoom: int) -> None:
         '''Remove every tile from a particular tileset and zoom'''
@@ -389,3 +450,13 @@ class Storage:
         cur.execute(f'''DELETE FROM "{self.__schema}"."{id}"
                         WHERE zoom = %s AND x = %s AND y = %s''',
                     (tile.zoom, tile.x, tile.y))
+
+
+def data_columns(layers) -> sql.Composable:
+    return sql.SQL(', ').join([sql.Identifier(f"{layer}_data")
+                               for layer in layers])
+
+
+def generated_columns(layers) -> sql.Composable:
+    return sql.SQL(', ').join([sql.Identifier(f"{layer}_generated")
+                               for layer in layers])

--- a/tilekiln/tileset.py
+++ b/tilekiln/tileset.py
@@ -21,6 +21,7 @@ class Tileset:
 
     storage: Storage
     id: str
+    layers: list[str]
     minzoom: int
     maxzoom: int
     tilejson: str
@@ -28,9 +29,10 @@ class Tileset:
     @classmethod
     def from_config(cls, storage: Storage, config: Config):
         '''Create a tileset from a Storage and Config'''
-        return cls(storage, config.id, config.minzoom, config.maxzoom,
+        return cls(storage, config.id, config.layer_names(), config.minzoom, config.maxzoom,
                    config.tilejson('REPLACED_BY_SERVER'))
 
+    # todo: this should really be in storage
     @classmethod
     def from_id(cls, storage: Storage, id: str) -> Tileset:
         '''
@@ -38,24 +40,26 @@ class Tileset:
 
         This pulls the metadata from the storage
         '''
+
+        layers = [layer for layer in storage.get_layer_ids(id)]
         minzoom = storage.get_minzoom(id)
         maxzoom = storage.get_minzoom(id)
         tilejson = storage.get_tilejson(id, 'REPLACED_BY_SERVER')
-        return cls(storage, id, minzoom, maxzoom, tilejson)
+        return cls(storage, id, layers, minzoom, maxzoom, tilejson)
 
     def prepare_storage(self) -> None:
-        self.storage.create_tileset(self.id, self.minzoom, self.maxzoom,
+        self.storage.create_tileset(self.id, self.layers, self.minzoom, self.maxzoom,
                                     self.tilejson)
 
     def update_storage_metadata(self) -> None:
         '''Sets the metadata in storage'''
-        self.storage.set_metadata(self.id, self.minzoom, self.maxzoom,
+        self.storage.set_metadata(self.id, self.layers, self.minzoom, self.maxzoom,
                                   self.tilejson)
 
-    def get_tile(self, tile: Tile) -> tuple[bytes | None, datetime.datetime | None]:
+    def get_tile(self, tile: Tile) -> tuple[dict[str, bytes] | None, datetime.datetime | None]:
         if tile.zoom < self.minzoom or tile.zoom > self.maxzoom:
             raise tilekiln.errors.ZoomNotDefined
         return self.storage.get_tile(self.id, tile)
 
-    def save_tile(self, tile: Tile, data: bytes) -> datetime.datetime | None:
-        return self.storage.save_tile(self.id, tile, data)
+    def save_tile(self, tile: Tile, layers: dict[str, bytes]) -> datetime.datetime | None:
+        return self.storage.save_tile(self.id, tile, layers)


### PR DESCRIPTION
This substantially alters the in-DB storage format, breaking each tile into layers. In the future this will allow for tiles to be refreshed per-layer, reducing excess work. A tile database will need to be re-created after this change.

It also substantially improves SQL building and escaping, along with better test coverage of Storage

Fixes #58 